### PR TITLE
feat: 入力待ち時のNotification hookを追加

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -ExecutionPolicy Bypass -File \"$(wslpath -w ~/.claude/windows-notify.ps1)\" -Title \"入力待ち\" -Message \"Claudeが許可または入力を待っています\" -Sound IM -IncludeWorkingDirectory"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## 概要

Claude Code が許可待ち・入力待ち状態になったときに Windows トースト通知を送信する Notification hook を追加。

## 変更内容

- `settings.json` に `Notification` hook を追加
- 既存の `Stop` hook（応答完了通知）と同じ `windows-notify.ps1` を使用
- Sound を `IM` に設定し、Stop hook の `Reminder` と区別

Closes #5