### PR TITLE
fix: Worktree遅延クリーンアップでStop hookのENOENTエラーを修正

### DIFF
--- a/skills/gh-pr-approve/cleanup-after-merge.sh
+++ b/skills/gh-pr-approve/cleanup-after-merge.sh
@@ -43,18 +43,11 @@ if [ "$WORKTREE_PATH" != "none" ]; then
       | sed 's|refs/heads/||')
   fi
 
-  # Worktree削除
-  git -C "$MAIN_REPO" worktree remove "$WORKTREE_PATH" 2>/dev/null || \
-    git -C "$MAIN_REPO" worktree prune
-  echo "Worktree removed: $WORKTREE_PATH"
-
-  # ローカルブランチ削除
-  if [ -n "$BRANCH_TO_DELETE" ]; then
-    git -C "$MAIN_REPO" branch -d "$BRANCH_TO_DELETE" 2>/dev/null || true
-    echo "Local branch deleted: $BRANCH_TO_DELETE"
-  fi
+  # Worktree削除を遅延（CWDが削除済みディレクトリになりStop hookがENOENTで失敗するため）
+  echo "$MAIN_REPO|$WORKTREE_PATH|$BRANCH_TO_DELETE" >> ~/.claude/pending-worktree-cleanup.txt
+  echo "Worktree cleanup deferred: $WORKTREE_PATH (will be cleaned up on next worktree creation)"
 else
-  # ローカルブランチ削除
+  # Worktree未使用時はローカルブランチを即座に削除
   if [ -n "$BRANCH_TO_DELETE" ]; then
     git -C "$MAIN_REPO" branch -d "$BRANCH_TO_DELETE" 2>/dev/null || true
     echo "Local branch deleted: $BRANCH_TO_DELETE"

--- a/skills/gh-pr-approve/cleanup-stale-worktrees.sh
+++ b/skills/gh-pr-approve/cleanup-stale-worktrees.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 前回セッションで遅延されたWorktree削除を実行する
+PENDING_FILE="$HOME/.claude/pending-worktree-cleanup.txt"
+
+[ -f "$PENDING_FILE" ] || exit 0
+
+while IFS='|' read -r REPO WT BRANCH; do
+  # Worktree削除
+  git -C "$REPO" worktree remove "$WT" 2>/dev/null || git -C "$REPO" worktree prune
+  echo "Cleaned up worktree: $WT"
+
+  # ローカルブランチ削除
+  if [ -n "$BRANCH" ]; then
+    git -C "$REPO" branch -d "$BRANCH" 2>/dev/null || true
+    echo "Cleaned up branch: $BRANCH"
+  fi
+done < "$PENDING_FILE"
+
+rm -f "$PENDING_FILE"

--- a/skills/gh-worktree-branch/SKILL.md
+++ b/skills/gh-worktree-branch/SKILL.md
@@ -19,6 +19,16 @@ allowed-tools:
 
 ## 実行フロー（引数ありの場合）
 
+### 0. 古い Worktree の自動掃除
+
+前回のセッションで削除が遅延された Worktree がある場合、自動的に削除する:
+
+```bash
+bash ~/.claude/skills/gh-pr-approve/cleanup-stale-worktrees.sh
+```
+
+出力がない場合は掃除不要。
+
 ### 1. リポジトリ情報を取得
 
 ```bash

--- a/skills/gh-worktree-from-issue/SKILL.md
+++ b/skills/gh-worktree-from-issue/SKILL.md
@@ -23,6 +23,16 @@ allowed-tools:
 
 ## 実行手順
 
+### 0. 古い Worktree の自動掃除
+
+前回のセッションで削除が遅延された Worktree がある場合、自動的に削除する:
+
+```bash
+bash ~/.claude/skills/gh-pr-approve/cleanup-stale-worktrees.sh
+```
+
+出力がない場合は掃除不要。
+
 ### 1. 引数の確認とIssue取得
 
 **引数がある場合（例: `/gh-worktree-from-issue 123`）:**


### PR DESCRIPTION
## 概要

PRマージ後にWorktreeを即座に削除するとCWDが無効になり、Stop hookがENOENTエラーで失敗する問題を修正。

## 変更内容

- `cleanup-after-merge.sh`: Worktree削除を即時実行から遅延方式に変更（`~/.claude/pending-worktree-cleanup.txt` に記録）
- `cleanup-stale-worktrees.sh`: 遅延されたWorktreeを次回のWorktree作成時に掃除する新規スクリプト
- `gh-worktree-branch/SKILL.md` / `gh-worktree-from-issue/SKILL.md`: ステップ0に自動掃除を追加

Closes #9