### PR TITLE
fix: bare worktree構造でMAIN_REPOに.bareが渡される問題を修正

### DIFF
--- a/skills/gh-finish/SKILL.md
+++ b/skills/gh-finish/SKILL.md
@@ -178,8 +178,12 @@ git push -u origin $(git branch --show-current)
 git worktree list
 ```
 
-1行目のパスを記憶する（Step 5 の後処理で使用）。
-Worktree なし（1行のみ）の場合は `none` として扱う。
+**MAIN_REPO の決定ルール（Step 5 で使用）:**
+
+- `git rev-parse --show-toplevel` の出力を MAIN_REPO とする
+- ただし bare worktree 構造（`.bare` ディレクトリがある場合）は、`git worktree list` でデフォルトブランチ（master/main）のワークツリーパスを MAIN_REPO とする
+  - bare リポジトリのパス（`.bare`）は絶対に MAIN_REPO に使わないこと（bare repo では `git checkout` が実行できない）
+- Worktree なし（1行のみ）の場合、現在の作業ディレクトリを MAIN_REPO、Worktree パスは `none` として扱う
 
 → Step 2 へ
 

--- a/skills/gh-pr-approve/SKILL.md
+++ b/skills/gh-pr-approve/SKILL.md
@@ -45,7 +45,13 @@ GitHub App Bot を使用するには、以下のセットアップが必要で�
 git worktree list
 ```
 
-出力の1行目がメインリポジトリのパス。**以下の 2 つを独立した Bash コマンドとして順番に実行する（1つの Bash 呼び出しにまとめないこと）:**
+**MAIN_REPO の決定ルール:**
+
+- `git worktree list` の1行目が `.bare` を含む場合 → **bare worktree 構造**。デフォルトブランチ（master/main）のワークツリーパス（例: `<プロジェクトルート>/master`）を MAIN_REPO とする
+- `.bare` でない場合 → 1行目のパスを MAIN_REPO とする
+- **bare リポジトリのパス（`.bare`）は絶対に MAIN_REPO に使わないこと**（bare repo では `git checkout` が実行できず fatal エラーになる）
+
+**以下の 2 つを独立した Bash コマンドとして順番に実行する（1つの Bash 呼び出しにまとめないこと）:**
 
 **Bash コマンド 1:**
 ```bash

--- a/skills/gh-pr-approve/cleanup-after-merge.sh
+++ b/skills/gh-pr-approve/cleanup-after-merge.sh
@@ -14,6 +14,12 @@ if [ "${WORKTREE_PATH,,}" = "none" ]; then
   WORKTREE_PATH="none"
 fi
 
+# bare リポジトリ検出: .bare ディレクトリが MAIN_REPO として渡された場合は拒否
+if git -C "$MAIN_REPO" rev-parse --is-bare-repository 2>/dev/null | grep -q "true"; then
+  echo "ERROR: MAIN_REPO '$MAIN_REPO' is a bare repository. Pass the default-branch worktree path (e.g. .../master) instead." >&2
+  exit 1
+fi
+
 # ガード: Worktree内から実行するとcwd消失でBashツールが壊れるため防止
 if [ "$WORKTREE_PATH" != "none" ]; then
   CURRENT_DIR="$(pwd -P 2>/dev/null || echo "")"


### PR DESCRIPTION
Closes #31

## 問題

bare worktree 構造（`.bare` + `master/` ディレクトリ）のリポジトリで後処理スクリプトに `.bare` パスが MAIN_REPO として渡され、`fatal: this operation must be run in a work tree` エラーが発生していた。結果として CWD が削除済みの Worktree パスに固定され、以降の全 Bash コマンドが失敗する状態に陥っていた。

## 修正内容

- `gh-finish/SKILL.md`: Step 1 に MAIN_REPO 決定ルールを追記（bare repo のパスは使用禁止、`git rev-parse --show-toplevel` を使用）
- `gh-pr-approve/SKILL.md`: Step 0 に同様の MAIN_REPO 決定ルールを追記
- `cleanup-after-merge.sh`: bare リポジトリが渡された場合に即座にエラー終了して誤動作を防止