### PR TITLE
fix: detect-context.sh の DEFAULT_BRANCH に feature ブランチが混入するバグを修正

### DIFF
--- a/skills/_shared/detect-context.sh
+++ b/skills/_shared/detect-context.sh
@@ -13,6 +13,16 @@ DEFAULT_BRANCH=$(gh api repos/:owner/:repo --jq '.default_branch' 2>/dev/null) \
   || DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | awk '/HEAD branch/{print $NF}') \
   || DEFAULT_BRANCH="main"
 
+# / が含まれていたら feature ブランチと判断して再検証
+if echo "$DEFAULT_BRANCH" | grep -q '/'; then
+  for candidate in main master; do
+    if git rev-parse --verify "origin/$candidate" &>/dev/null 2>&1; then
+      DEFAULT_BRANCH="$candidate"
+      break
+    fi
+  done
+fi
+
 # --- IS_DEFAULT ---
 if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
   IS_DEFAULT="true"


### PR DESCRIPTION
Closes #35

## 変更内容

`detect-context.sh` の DEFAULT_BRANCH 取得後に、`/` を含む値（feature ブランチ）が混入した場合、`main` → `master` の順で存在確認してフォールバックするバリデーションを追加。

## 原因

旧スキルで作成した `feature/issue-N-slug` ブランチが `origin/HEAD` に残り、fallback の `git remote show origin` がそれを DEFAULT_BRANCH として返していた。

## 修正箇所

`skills/_shared/detect-context.sh` — DEFAULT_BRANCH 取得ロジックの直後に検証ブロックを挿入。
